### PR TITLE
Patch 2 - Grammar, Spelling, Phrasing updates

### DIFF
--- a/docs/_pages/01-overview-02-getting-started.md
+++ b/docs/_pages/01-overview-02-getting-started.md
@@ -7,9 +7,9 @@ permalink: /overview/getting-started/index.html
 
 ### Basic setup
 
-Out of the box Fluidity works using PetaPoco as the persistence layer, as this is what ships with Umbraco. It is possible to change this if you like using a custom [Repository]({{ site.baseurl }}/api/repositories/), but for the sake of getting started, we'll assume you are using this default strategy.
+Out of the box Fluidity works using PetaPoco as the persistence layer as this is what ships with Umbraco. However, it is possible to use a custom [Repository]({{ site.baseurl }}/api/repositories/) if you prefer. For the sake of getting started, we'll assume you are using this default strategy.
 
-Start by setting up a database table for you model (you might want to populate it with some dummy data as well whilst learning). We’ll use the following as an example
+Start by setting up a database table for your model (you might want to populate it with some dummy data as well whilst learning). We’ll use the following as an example:
 
 ````sql
 CREATE TABLE [Person] (
@@ -23,7 +23,7 @@ CREATE TABLE [Person] (
 );
 ````
 
-Then, create the associated poco model
+Then, create the associated poco model:
 
 ````csharp
 [TableName("Person")]
@@ -40,7 +40,7 @@ public class Person
 }
 ````
 
-With the database and model setup, we can now start to configure Fluidity itself. The entry point for a Fluidity configuration is via a class that inherits from the abstract base class `FluidityConfigModule`. This class exposes a single method, `Configure`, which is passed a `FluidityConfig` instance against which you can start configuring your UI.
+With the database and model setup, we can now start to configure Fluidity itself. The entry point for a Fluidity configuration is via a class that inherits from the abstract base class `FluidityConfigModule`. This class exposes a single method, `Configure`, which is passed a `FluidityConfig` instance. It is against this instance that you configure your UI.
 
 ````csharp
 public class FluidityBootstrap : FluidityConfigModule

--- a/docs/_pages/02-api-00-conventions.md
+++ b/docs/_pages/02-api-00-conventions.md
@@ -7,7 +7,7 @@ permalink: /api/conventions/index.html
 
 ### Fluent Conventions
 
-Most configuration methods in Fluidity aim to be fluent in nature, in that they return a relevant config instance to allow you to chain multiple method calls together in one. For those who prefer to be a bit more verbose, many methods also accept an optional lambda expression to allow you to pass in a delegate to perform the inner configuration of the element being defined.
+Most configuration methods in Fluidity aim to be fluent in nature, in that they return a relevant config instance allowing you to chain multiple method calls together in one. For those who prefer to be a bit more verbose, many methods also accept an optional lambda expression which allows you to pass in a delegate to perform the inner configuration of the element being defined.
 
 ````csharp
 // Chaining example

--- a/docs/_pages/02-api-02-trees.md
+++ b/docs/_pages/02-api-02-trees.md
@@ -5,7 +5,7 @@ title: Trees
 permalink: /api/trees/index.html
 ---
 
-A tree is a hierarchical structure to help organise a section into logical sub-sections and is accessed in the main side panel of the Umbraco interface. In Fluidity, a section may only have a single tree definition, however you can use folder nodes to help organise the tree structure how you need it.
+A tree is a hierarchical structure that helps organise a section into logical sub-sections and is accessed in the main side panel of the Umbraco interface. In Fluidity, a section may only have a single tree definition, however you can use folder nodes to help organise the tree structure how you need it.
 
 ### Defining a tree
 


### PR DESCRIPTION
Various changes to the phrasing, grammar, and spelling to a few pages. Makes the reading a little easier particularly on the longer sentences.

--Matt, on the Trees page, I think the references to collections and to folders needs to stand out just a little bit more. It's easy to miss, thought I'd mention it :-)