### PR TITLE
Make remove option configurable on entity picker

### DIFF
--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/package.manifest
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/package.manifest
@@ -31,6 +31,12 @@
 						description: "Show a button to redirect the back office to the editor page of the select node",
 						key: "showOpen",
 						view: "boolean"
+					},
+					{
+						label: "Disable remove button",
+						description: "Disable the remove button so that editors cannot delete an existing relationship",
+						key: "disableRemove",
+						view: "boolean"
 					}
 				]
 			}

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/package.manifest
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/package.manifest
@@ -1,10 +1,10 @@
-﻿{
+{
 	propertyEditors: [
 		{
 			alias: "Fluidity.EntityPicker",
 			name: "Fluidity Entity Picker",
 			editor: {
-			view: "~/app_plugins/fluidity/propertyeditors/entitypicker.html"
+				view: "~/app_plugins/fluidity/propertyeditors/entitypicker.html"
 			},
 			prevalues: {
 				fields: [
@@ -28,14 +28,14 @@
 					},
 					{
 						label: "Show open button",
-						description: "Show a button to redirect the back office to the editor page of the select node",
+						description: "Show a button to redirect the back office to the editor page of the selected item",
 						key: "showOpen",
 						view: "boolean"
 					},
 					{
-						label: "Disable remove button",
-						description: "Disable the remove button so that editors cannot delete an existing relationship",
-						key: "disableRemove",
+						label: "Show remove button",
+						description: "Show a button to remove the linked item",
+						key: "showRemove",
 						view: "boolean"
 					}
 				]

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.controller.js
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.controller.js
@@ -15,8 +15,7 @@
         var dataView = aliases.length >= 3 ? aliases[2] : "";
 
         $scope.renderModel = [];
-        $scope.dialogEditor = editorState && editorState.current && editorState.current.isDialogEditor;
-        $scope.isReadOnly = editorState && editorState.current && editorState.current.collectionIsReadOnly;
+        $scope.dialogEditor = editorState && editorState.current && editorState.current.isDialogEditor;        
 
         // Sortable options
         $scope.sortableOptions = {

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.controller.js
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.controller.js
@@ -16,6 +16,7 @@
 
         $scope.renderModel = [];
         $scope.dialogEditor = editorState && editorState.current && editorState.current.isDialogEditor;
+        $scope.isReadOnly = editorState && editorState.current && editorState.current.collectionIsReadOnly;
 
         // Sortable options
         $scope.sortableOptions = {
@@ -23,6 +24,12 @@
             tolerance: "pointer",
             scroll: true,
             zIndex: 6000
+        };
+
+        // Config options
+        $scope.configOptions = {
+            showOpen: $scope.model.config.showOpen.length ? $scope.model.config.showOpen : "0",
+            showRemove: $scope.model.config.showRemove.length ? $scope.model.config.showRemove : "1"
         };
 
         // Dialog options

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.html
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.html
@@ -9,9 +9,9 @@
                 published="true"
                 description="'/' + node.section + '/' + node.collection + '/' + node.id"
                 sortable="!sortableOptions.disabled"
-                allow-open="model.config.showOpen"
+                allow-open="configOptions.showOpen"
                 on-open="open(node.section, node.collection, node.id)"
-                allow-remove="!model.config.disableRemove"
+                allow-remove="!isReadOnly && configOptions.showRemove"
                 on-remove="remove($index)">
             </umb-node-preview>
         </div>

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.html
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.html
@@ -11,7 +11,7 @@
                 sortable="!sortableOptions.disabled"
                 allow-open="configOptions.showOpen"
                 on-open="open(node.section, node.collection, node.id)"
-                allow-remove="!isReadOnly && configOptions.showRemove"
+                allow-remove="configOptions.showRemove"
                 on-remove="remove($index)">
             </umb-node-preview>
         </div>

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.html
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/propertyeditors/entitypicker.html
@@ -11,7 +11,7 @@
                 sortable="!sortableOptions.disabled"
                 allow-open="model.config.showOpen"
                 on-open="open(node.section, node.collection, node.id)"
-                allow-remove="true"
+                allow-remove="!model.config.disableRemove"
                 on-remove="remove($index)">
             </umb-node-preview>
         </div>


### PR DESCRIPTION
Allows for the remove option to be configurable on the entity picker. 

Use case being if you want to show relations between two entities and these are set using code behind, rather than within the back office. Being able to view and update the related entity via the picker is useful but removing the relationship is not desired.

Relates to #60 