### PR TITLE
Add options over create/update/delete

### DIFF
--- a/docs/_pages/02-api-04-collections.md
+++ b/docs/_pages/02-api-04-collections.md
@@ -317,13 +317,52 @@ Sets the collection as read only and disables any CRUD operations from being per
 collectionConfig.MakeReadOnly();
 ````
 
+### Disable the option to create
+{: .mt}
+
+#### DisableCreate() *: FluidityCollectionConfig&lt;TEntityType&gt;*
+{: .signature}
+
+Disables the option to create entities on the current collection. An entity could be created via code-behind and then only editing is allowed in the UI for example.
+
+````csharp
+// Example
+collectionConfig.DisableCreate();
+````
+
+### Disable the option to update
+{: .mt}
+
+#### DisableUpdate() *: FluidityCollectionConfig&lt;TEntityType&gt;*
+{: .signature}
+
+Disables the option to update entities on the current collection. An entity can be created, but further editing is not allowed. 
+
+````csharp
+// Example
+collectionConfig.DisableUpdate();
+````
+
+### Disable the option to delete
+{: .mt}
+
+#### DisableDelete() *: FluidityCollectionConfig&lt;TEntityType&gt;*
+{: .signature}
+
+Disables the option to delete entities on the current collection. Useful if the data needs to be retained and visible. See also [defining a deleted flag](#defining-a-deleted-flag).
+
+````csharp
+// Example
+collectionConfig.DisableDelete();
+````
+
 ### Setting a view mode
 {: .mt}
 
 #### SetViewMode(FluidityViewMode viewMode) *: FluidityCollectionConfig&lt;TEntityType&gt;*
 {: .signature}
 
-Sets the view mode of the current collection. Opions are `Tree` or `List`. When set to `Tree` then all entities will appear as nodes in the tree. When set as `List` then entities will be hidden from the tree and show in a [list view]({{ site.baseurl }}/api/collections/list-view/) in the right hand content area.
+Sets the view mode of the current collection. Options are `Tree` or `List`. When set to `Tree` then all entities will appear as nodes in the tree. When set as `List` then entities will be hidden from the tree and show in a [list view]({{ site.baseurl }}/api/collections/list-view/) in the right hand content area.
 
 ````csharp
 // Example

--- a/src/Fluidity/Configuration/FluidityCollectionConfig.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig.cs
@@ -56,8 +56,6 @@ namespace Fluidity.Configuration
         protected bool _isVisibleInTree;
         internal bool IsVisibleInTree => _isVisibleInTree;
 
-        internal bool IsReadOnly => !_canCreate && !_canUpdate && !_canDelete;
-
         protected bool _canCreate;
         internal bool CanCreate => _canCreate;
 

--- a/src/Fluidity/Configuration/FluidityCollectionConfig.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig.cs
@@ -56,8 +56,7 @@ namespace Fluidity.Configuration
         protected bool _isVisibleInTree;
         internal bool IsVisibleInTree => _isVisibleInTree;
 
-        protected bool _isReadOnly;
-        internal bool IsReadOnly => _isReadOnly;
+        internal bool IsReadOnly => !_canCreate && !_canUpdate && !_canDelete;
 
         protected bool _canCreate;
         internal bool CanCreate => _canCreate;

--- a/src/Fluidity/Configuration/FluidityCollectionConfig.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig.cs
@@ -59,6 +59,15 @@ namespace Fluidity.Configuration
         protected bool _isReadOnly;
         internal bool IsReadOnly => _isReadOnly;
 
+        protected bool _canCreate;
+        internal bool CanCreate => _canCreate;
+
+        protected bool _canUpdate;
+        internal bool CanUpdate => _canUpdate;
+
+        protected bool _canDelete;
+        internal bool CanDelete => _canDelete;
+
         protected FluidityViewMode _viewMode;
         internal FluidityViewMode ViewMode => _viewMode;
 
@@ -119,6 +128,9 @@ namespace Fluidity.Configuration
             _iconSingular = iconSingular ?? "icon-folder";
             _iconPlural = iconPlural ?? "icon-folder";
             _isVisibleInTree = true;
+            _canCreate = true;
+            _canUpdate = true;
+            _canDelete = true;
 
             _containerMenuItems = new List<MenuItem>();
             _entityMenuItems = new List<MenuItem>();

--- a/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Fluidity.Actions;
 using Fluidity.Data;
 using Umbraco.Core;
 using Umbraco.Web.Models.Trees;
@@ -225,6 +226,36 @@ namespace Fluidity.Configuration
         }
 
         /// <summary>
+        /// Allow for creating entities in collection.
+        /// </summary>
+        /// <returns>The collection configuration.</returns>
+        public FluidityCollectionConfig<TEntityType> DisableCreate()
+        {
+            _canCreate = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Allow for updating entities in collection.
+        /// </summary>
+        /// <returns>The collection configuration.</returns>
+        public FluidityCollectionConfig<TEntityType> DisableUpdate()
+        {
+            _canUpdate = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Allow for deleting entities in collection.
+        /// </summary>
+        /// <returns>The collection configuration.</returns>
+        public FluidityCollectionConfig<TEntityType> DisableDelete()
+        {
+            _canDelete = false;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the view mode of the collection. Can be either 'Tree' or 'List'.
         /// </summary>
         /// <param name="viewMode">The view mode.</param>
@@ -342,7 +373,12 @@ namespace Fluidity.Configuration
         /// <returns>The list view configuration.</returns>
         public new FluidityListViewConfig<TEntityType> ListView(FluidityListViewConfig<TEntityType> listViewConfig)
         {
-            _listView = listViewConfig;
+            if (_canDelete)
+            {
+                listViewConfig.AddBulkAction<FluidityDeleteBulkAction>();
+            }
+
+            _listView = listViewConfig;                       
             return listViewConfig;
         }
 

--- a/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
@@ -220,8 +220,10 @@ namespace Fluidity.Configuration
         /// </summary>
         /// <returns>The collection configuration.</returns>
         public FluidityCollectionConfig<TEntityType> MakeReadOnly()
-        {
-            _isReadOnly = true;
+        {            
+            _canCreate = false;
+            _canUpdate = false;
+            _canDelete = false;
             return this;
         }
 
@@ -373,7 +375,7 @@ namespace Fluidity.Configuration
         /// <returns>The list view configuration.</returns>
         public new FluidityListViewConfig<TEntityType> ListView(FluidityListViewConfig<TEntityType> listViewConfig)
         {
-            if (!_isReadOnly && _canDelete)
+            if (_canDelete)
             {
                 listViewConfig.AddBulkAction<FluidityDeleteBulkAction>();
             }

--- a/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
@@ -373,7 +373,7 @@ namespace Fluidity.Configuration
         /// <returns>The list view configuration.</returns>
         public new FluidityListViewConfig<TEntityType> ListView(FluidityListViewConfig<TEntityType> listViewConfig)
         {
-            if (_canDelete)
+            if (!_isReadOnly && _canDelete)
             {
                 listViewConfig.AddBulkAction<FluidityDeleteBulkAction>();
             }

--- a/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
@@ -228,7 +228,7 @@ namespace Fluidity.Configuration
         }
 
         /// <summary>
-        /// Allow for creating entities in collection.
+        /// Disable creating entities in collection.
         /// </summary>
         /// <returns>The collection configuration.</returns>
         public FluidityCollectionConfig<TEntityType> DisableCreate()
@@ -238,7 +238,7 @@ namespace Fluidity.Configuration
         }
 
         /// <summary>
-        /// Allow for updating entities in collection.
+        /// Disable updating entities in collection.
         /// </summary>
         /// <returns>The collection configuration.</returns>
         public FluidityCollectionConfig<TEntityType> DisableUpdate()
@@ -248,7 +248,7 @@ namespace Fluidity.Configuration
         }
 
         /// <summary>
-        /// Allow for deleting entities in collection.
+        /// Disable deleting entities in collection.
         /// </summary>
         /// <returns>The collection configuration.</returns>
         public FluidityCollectionConfig<TEntityType> DisableDelete()

--- a/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
+++ b/src/Fluidity/Configuration/FluidityCollectionConfig`T.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Fluidity.Actions;
 using Fluidity.Data;
@@ -220,10 +222,10 @@ namespace Fluidity.Configuration
         /// </summary>
         /// <returns>The collection configuration.</returns>
         public FluidityCollectionConfig<TEntityType> MakeReadOnly()
-        {            
-            _canCreate = false;
-            _canUpdate = false;
-            _canDelete = false;
+        {                        
+            DisableCreate();
+            DisableUpdate();
+            DisableDelete();
             return this;
         }
 
@@ -253,7 +255,12 @@ namespace Fluidity.Configuration
         /// <returns>The collection configuration.</returns>
         public FluidityCollectionConfig<TEntityType> DisableDelete()
         {
-            _canDelete = false;
+            _canDelete = false;        
+            if (_listView != null)
+            {
+                _listView.DefaultBulkActions.RemoveAll(x => x.GetType() == typeof(FluidityDeleteBulkAction));
+            }
+            
             return this;
         }
 
@@ -377,7 +384,7 @@ namespace Fluidity.Configuration
         {
             if (_canDelete)
             {
-                listViewConfig.AddBulkAction<FluidityDeleteBulkAction>();
+                listViewConfig.DefaultBulkActions.Add(new FluidityDeleteBulkAction());
             }
 
             _listView = listViewConfig;                       

--- a/src/Fluidity/Configuration/FluidityEditorFieldConfig.cs
+++ b/src/Fluidity/Configuration/FluidityEditorFieldConfig.cs
@@ -44,7 +44,6 @@ namespace Fluidity.Configuration
 	    protected bool _isReadOnly;
 	    internal bool IsReadOnly => _isReadOnly;
 
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="FluidityEditorFieldConfig"/> class.
 		/// </summary>

--- a/src/Fluidity/Configuration/FluidityListViewConfig.cs
+++ b/src/Fluidity/Configuration/FluidityListViewConfig.cs
@@ -19,9 +19,8 @@ namespace Fluidity.Configuration
         protected int _pageSize;
         internal int PageSize => _pageSize;
 
-        protected List<FluidityBulkAction> _defaultBulkActions;
         protected List<FluidityBulkAction> _bulkActions;
-        internal IEnumerable<FluidityBulkAction> BulkActions => _bulkActions.Concat(_defaultBulkActions);
+        internal IEnumerable<FluidityBulkAction> BulkActions => _bulkActions;
 
         protected List<FluidityDataViewConfig> _dataViews;
         internal IEnumerable<FluidityDataViewConfig> DataViews => _dataViews;
@@ -42,7 +41,6 @@ namespace Fluidity.Configuration
         protected FluidityListViewConfig()
         {
             _pageSize = 20;
-            _defaultBulkActions = new List<FluidityBulkAction>(new [] { new FluidityDeleteBulkAction() });
             _bulkActions = new List<FluidityBulkAction>();
             _dataViews = new List<FluidityDataViewConfig>();
             _dataViewsBuilder = new DefaultFluidityDataViewsBuilder(this);

--- a/src/Fluidity/Configuration/FluidityListViewConfig.cs
+++ b/src/Fluidity/Configuration/FluidityListViewConfig.cs
@@ -19,8 +19,11 @@ namespace Fluidity.Configuration
         protected int _pageSize;
         internal int PageSize => _pageSize;
 
+        protected List<FluidityBulkAction> _defaultBulkActions;
+        internal ICollection<FluidityBulkAction> DefaultBulkActions => _defaultBulkActions;
+
         protected List<FluidityBulkAction> _bulkActions;
-        internal IEnumerable<FluidityBulkAction> BulkActions => _bulkActions;
+        internal IEnumerable<FluidityBulkAction> BulkActions => _bulkActions.Concat(_defaultBulkActions);
 
         protected List<FluidityDataViewConfig> _dataViews;
         internal IEnumerable<FluidityDataViewConfig> DataViews => _dataViews;
@@ -41,6 +44,7 @@ namespace Fluidity.Configuration
         protected FluidityListViewConfig()
         {
             _pageSize = 20;
+            _defaultBulkActions = new List<FluidityBulkAction>();
             _bulkActions = new List<FluidityBulkAction>();
             _dataViews = new List<FluidityDataViewConfig>();
             _dataViewsBuilder = new DefaultFluidityDataViewsBuilder(this);

--- a/src/Fluidity/Web/Api/FluidityApiController.cs
+++ b/src/Fluidity/Web/Api/FluidityApiController.cs
@@ -129,17 +129,19 @@ namespace Fluidity.Web.Api
             }
 
             // Get or create entity
-            var entity = postModel.Id != null && !postModel.Id.Equals(defaultId)
+            var isNew = postModel.Id == null || postModel.Id.Equals(defaultId);
+            var entity = !isNew
                 ? Context.Services.EntityService.GetEntity(collectionConfig, postModel.Id)
                 : Context.Services.EntityService.NewEntity(collectionConfig);
 
             // Map property values
+            var isEditable = isNew && collectionConfig.CanCreate || !isNew && collectionConfig.CanUpdate;
             var mapper = new FluidityEntityMapper();
-            entity = mapper.FromPostModel(sectionConfig, collectionConfig, postModel, entity);
+            entity = mapper.FromPostModel(sectionConfig, collectionConfig, postModel, entity, !isEditable);
 
             // Validate the property values (review ContentItemValidationHelper)
             var validator = new FluidityEntityPostValidator();
-            validator.Validate(ModelState, postModel, entity, collectionConfig);
+            validator.Validate(ModelState, postModel, entity, collectionConfig, !isEditable);
 
             // Check to see if model is valid
             if (!ModelState.IsValid)

--- a/src/Fluidity/Web/Models/FluidityCollectionDisplayModel.cs
+++ b/src/Fluidity/Web/Models/FluidityCollectionDisplayModel.cs
@@ -34,9 +34,6 @@ namespace Fluidity.Web.Models
         [DataMember(Name = "description")]
         public string Description { get; set; }
 
-        [DataMember(Name = "isReadOnly")]
-        public bool IsReadOnly { get; set; }
-
         [DataMember(Name = "isSearchable")]
         public bool IsSearchable { get; set; }
 

--- a/src/Fluidity/Web/Models/FluidityCollectionDisplayModel.cs
+++ b/src/Fluidity/Web/Models/FluidityCollectionDisplayModel.cs
@@ -40,6 +40,15 @@ namespace Fluidity.Web.Models
         [DataMember(Name = "isSearchable")]
         public bool IsSearchable { get; set; }
 
+        [DataMember(Name = "canCreate")]
+        public bool CanCreate { get; set; }
+
+        [DataMember(Name = "canUpdate")]
+        public bool CanUpdate { get; set; }
+
+        [DataMember(Name = "canDelete")]
+        public bool CanDelete { get; set; }
+
         [DataMember(Name = "hasListView")]
         public bool HasListView { get; set; }
 

--- a/src/Fluidity/Web/Models/FluidityEntityEditModel.cs
+++ b/src/Fluidity/Web/Models/FluidityEntityEditModel.cs
@@ -26,8 +26,8 @@ namespace Fluidity.Web.Models
         [DataMember(Name = "tree", IsRequired = true)]
         public string Tree { get; set; }
 
-        [DataMember(Name = "collectionIsReadOnly")]
-        public bool CollectionIsReadOnly { get; set; }
+        [DataMember(Name = "collectionIsEditable")]
+        public bool CollectionIsEditable { get; set; }
 
         [DataMember(Name = "collectionNameSingular")]
         public string CollectionNameSingular { get; set; }

--- a/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
@@ -25,12 +25,11 @@ namespace Fluidity.Web.Models.Mappers
                 NamePlural = collection.NamePlural,
                 IconSingular = collection.IconSingular + (!collection.IconColor.IsNullOrWhiteSpace() ? " color-" + collection.IconColor : ""),
                 IconPlural = collection.IconPlural + (!collection.IconColor.IsNullOrWhiteSpace() ? " color-" + collection.IconColor : ""),
-                Description = collection.Description,
-                IsReadOnly = collection.IsReadOnly,
+                Description = collection.Description,                
                 IsSearchable = collection.SearchableProperties.Any(),
-                CanCreate = collection.IsReadOnly ? false : collection.CanCreate,
-                CanUpdate = collection.IsReadOnly ? false : collection.CanUpdate,
-                CanDelete = collection.IsReadOnly ? false : collection.CanDelete,
+                CanCreate = collection.CanCreate,
+                CanUpdate = collection.CanUpdate,
+                CanDelete = collection.CanDelete,
                 HasListView = collection.ViewMode == FluidityViewMode.List,
                 Path = collection.Path
             };

--- a/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
@@ -28,6 +28,9 @@ namespace Fluidity.Web.Models.Mappers
                 Description = collection.Description,
                 IsReadOnly = collection.IsReadOnly,
                 IsSearchable = collection.SearchableProperties.Any(),
+                CanCreate = collection.IsReadOnly ? false : collection.CanCreate,
+                CanUpdate = collection.IsReadOnly ? false : collection.CanUpdate,
+                CanDelete = collection.IsReadOnly ? false : collection.CanDelete,
                 HasListView = collection.ViewMode == FluidityViewMode.List,
                 Path = collection.Path
             };

--- a/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
@@ -119,7 +119,7 @@ namespace Fluidity.Web.Models.Mappers
                 HasNameProperty = collection.NameProperty != null,
                 Section = section.Alias,
                 Tree = section.Tree.Alias,
-                CollectionIsReadOnly = collection.IsReadOnly,
+                CollectionIsReadOnly = collection.IsReadOnly || !collection.CanUpdate,
                 Collection = collection.Alias,
                 CollectionNameSingular = collection.NameSingular,
                 CollectionNamePlural = collection.NamePlural,

--- a/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
@@ -119,7 +119,7 @@ namespace Fluidity.Web.Models.Mappers
                 HasNameProperty = collection.NameProperty != null,
                 Section = section.Alias,
                 Tree = section.Tree.Alias,
-                CollectionIsEditable = isNew && collection.CanCreate || collection.CanUpdate,
+                CollectionIsEditable = isNew && collection.CanCreate || !isNew && collection.CanUpdate,
                 Collection = collection.Alias,
                 CollectionNameSingular = collection.NameSingular,
                 CollectionNamePlural = collection.NamePlural,
@@ -150,8 +150,8 @@ namespace Fluidity.Web.Models.Mappers
                     if (tab.Fields != null)
                     {
                         foreach (var field in tab.Fields)
-                        {
-                            var dataTypeInfo = _dataTypeHelper.ResolveDataType(field, collection.IsReadOnly);
+                        {                            
+                            var dataTypeInfo = _dataTypeHelper.ResolveDataType(field, !display.CollectionIsEditable);
 
                             dataTypeInfo.PropertyEditor.ValueEditor.ConfigureForDisplay(dataTypeInfo.PreValues);
 
@@ -231,7 +231,7 @@ namespace Fluidity.Web.Models.Mappers
             return display;
         }
 
-        public object FromPostModel(FluiditySectionConfig section, FluidityCollectionConfig collection, FluidityEntityPostModel postModel, object entity)
+        public object FromPostModel(FluiditySectionConfig section, FluidityCollectionConfig collection, FluidityEntityPostModel postModel, object entity, bool isReadOnly)
         {
             var editorProps = collection.Editor.Tabs.SelectMany(x => x.Fields).ToArray();
 
@@ -271,7 +271,7 @@ namespace Fluidity.Web.Models.Mappers
                     additionalData.Add("cuid", ObjectExtensions.EncodeAsGuid(cuid));
                     additionalData.Add("puid", ObjectExtensions.EncodeAsGuid(puid));
 
-                    var dataTypeInfo = _dataTypeHelper.ResolveDataType(propConfig, collection.IsReadOnly);
+                    var dataTypeInfo = _dataTypeHelper.ResolveDataType(propConfig, isReadOnly);
                     var data = new ContentPropertyData(prop.Value, dataTypeInfo.PreValues, additionalData);
 
                     if (!dataTypeInfo.PropertyEditor.ValueEditor.IsReadOnly) {

--- a/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
@@ -119,7 +119,7 @@ namespace Fluidity.Web.Models.Mappers
                 HasNameProperty = collection.NameProperty != null,
                 Section = section.Alias,
                 Tree = section.Tree.Alias,
-                CollectionIsReadOnly = collection.IsReadOnly || !collection.CanUpdate,
+                CollectionIsEditable = isNew && collection.CanCreate || collection.CanUpdate,
                 Collection = collection.Alias,
                 CollectionNameSingular = collection.NameSingular,
                 CollectionNamePlural = collection.NamePlural,

--- a/src/Fluidity/Web/Trees/FluidityTreeController.cs
+++ b/src/Fluidity/Web/Trees/FluidityTreeController.cs
@@ -199,7 +199,7 @@ namespace Fluidity.Web.Trees
                         hasMenuItems = true;
                     }
 
-                    if (!currentCollectionConfig.IsReadOnly && currentCollectionConfig.CanDelete)
+                    if (currentCollectionConfig.CanDelete)
                     {
                         // We create a custom item as we need to direct all fluidity delete commands to the
                         // same view, where as the in built delete dialog looks for seperate views per tree
@@ -213,7 +213,7 @@ namespace Fluidity.Web.Trees
                 {
                     var hasMenuItems = false;
 
-                    if (!currentCollectionConfig.IsReadOnly && currentCollectionConfig.CanCreate)
+                    if (currentCollectionConfig.CanCreate)
                     {
                         // We create a custom item as we need to direct all fluidity create commands to the
                         // same view, where as the in built create dialog looks for seperate views per tree

--- a/src/Fluidity/Web/Trees/FluidityTreeController.cs
+++ b/src/Fluidity/Web/Trees/FluidityTreeController.cs
@@ -199,7 +199,7 @@ namespace Fluidity.Web.Trees
                         hasMenuItems = true;
                     }
 
-                    if (!currentCollectionConfig.IsReadOnly)
+                    if (!currentCollectionConfig.IsReadOnly && currentCollectionConfig.CanDelete)
                     {
                         // We create a custom item as we need to direct all fluidity delete commands to the
                         // same view, where as the in built delete dialog looks for seperate views per tree
@@ -213,7 +213,7 @@ namespace Fluidity.Web.Trees
                 {
                     var hasMenuItems = false;
 
-                    if (!currentCollectionConfig.IsReadOnly)
+                    if (!currentCollectionConfig.IsReadOnly && currentCollectionConfig.CanCreate)
                     {
                         // We create a custom item as we need to direct all fluidity create commands to the
                         // same view, where as the in built create dialog looks for seperate views per tree

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/backoffice/fluidity/edit.html
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/backoffice/fluidity/edit.html
@@ -45,7 +45,7 @@
                         label-key="buttons_returnToList">
                     </umb-button>
 
-                    <umb-button ng-if="!content.collectionIsReadOnly"
+                    <umb-button ng-if="content.collectionIsEditable"
                         type="submit"
                         button-style="success"
                         state="page.saveButtonState"

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/dashboards/dashboard.html
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/dashboards/dashboard.html
@@ -6,7 +6,7 @@
             <div class="inner">
 
                 <div class="fluidity__dashboard__item-overlay">
-                    <a ng-if="!collection.isReadOnly" href="#/{{ collection.section }}/fluidity/edit/{{collection.alias}}"><i class="icon-add"></i></a>
+                    <a ng-if="collection.canCreate" href="#/{{ collection.section }}/fluidity/edit/{{collection.alias}}"><i class="icon-add"></i></a>
                     <a  ng-if="collection.hasListView" href="#/{{ collection.section }}/fluidity/list/{{collection.alias}}"><i class="icon-link"></i></a>
                 </div>
 

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/directives/listview.html
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/directives/listview.html
@@ -5,7 +5,7 @@
         <umb-editor-sub-header-content-left>
 
             <!-- Create Button -->
-            <umb-editor-sub-header-section ng-if="collection && !collection.isReadOnly && !isAnythingSelected()">
+            <umb-editor-sub-header-section ng-if="collection && collection.canCreate && !isAnythingSelected()">
                 <div class="btn-group">
                     <a class="btn" href="#/{{collection.section}}/fluidity/edit/{{collection.alias}}">
                         <i class="{{collection.iconSingular}}"></i>
@@ -75,7 +75,7 @@
             </umb-editor-sub-header-section>
 
             <!-- Bulk Actions -->
-            <umb-editor-sub-header-section ng-if="!collection.isReadOnly && isAnythingSelected()">
+            <umb-editor-sub-header-section ng-if="isAnythingSelected()">
 
                 <umb-button ng-repeat="bulkAction in options.bulkActions"
                     type="button"

--- a/src/Fluidity/Web/WebApi/Validation/FluidityEntityPostValidator.cs
+++ b/src/Fluidity/Web/WebApi/Validation/FluidityEntityPostValidator.cs
@@ -34,12 +34,12 @@ namespace Fluidity.Web.WebApi.Validation
             : this(new UmbracoDataTypeHelper())
         { }
 
-        public void Validate(ModelStateDictionary modelState, FluidityEntityPostModel postModel, object entity, FluidityCollectionConfig config)
+        public void Validate(ModelStateDictionary modelState, FluidityEntityPostModel postModel, object entity, FluidityCollectionConfig config, bool isReadOnly)
         {
             var configProps = config.Editor?.Tabs.SelectMany(x => x.Fields).ToArray() ?? new FluidityEditorFieldConfig[0];
 
             if (ValidateProperties(modelState, postModel, configProps) == false) return;
-            if (ValidatePropertyData(modelState, postModel, configProps, config.IsReadOnly) == false) return;
+            if (ValidatePropertyData(modelState, postModel, configProps, isReadOnly) == false) return;
             if (ValidateDataAnnotations(modelState, entity) == false) return;
         }
 


### PR DESCRIPTION
Introduced a way to enable/disable options around create/update/delete.
Currently just limits the button options.

See #61 