### PR TITLE
Do not overwrite the returned entity from the repository

### DIFF
--- a/src/Fluidity/Data/FluidityRepository`T.cs
+++ b/src/Fluidity/Data/FluidityRepository`T.cs
@@ -99,13 +99,19 @@ namespace Fluidity.Data
 
                 if (args.Cancel)
                     return (TEntity)args.Entity.After;
+
+                entity = (TEntity)args.Entity.After;
             }
 
             entity = SaveImpl(entity);
 
             if (fireEvents)
             {
+                args.Entity.After = entity;
+
                 Fluidity.OnSavedEntity(args);
+
+                entity = (TEntity)args.Entity.After;
             }
 
             return entity;

--- a/src/Fluidity/Data/FluidityRepository`T.cs
+++ b/src/Fluidity/Data/FluidityRepository`T.cs
@@ -99,8 +99,6 @@ namespace Fluidity.Data
 
                 if (args.Cancel)
                     return (TEntity)args.Entity.After;
-
-                entity = (TEntity)args.Entity.After;
             }
 
             entity = SaveImpl(entity);
@@ -108,8 +106,6 @@ namespace Fluidity.Data
             if (fireEvents)
             {
                 Fluidity.OnSavedEntity(args);
-
-                entity = (TEntity)args.Entity.After;
             }
 
             return entity;

--- a/src/Fluidity/Services/FluidityEntityService.cs
+++ b/src/Fluidity/Services/FluidityEntityService.cs
@@ -236,10 +236,10 @@ namespace Fluidity.Services
 
             using (var repo = RepositoryFactory.GetRepository(collection))
             {
-                repo?.Save(entity);
-            }
+                var savedEntity = repo?.Save(entity);
 
-            return entity;
+                return savedEntity;
+            }
         }
 
         public void DeleteEntity(FluidityCollectionConfig collection, object id)


### PR DESCRIPTION
When using a custom Repository, I find that the entity in the backoffice is not updated when saved, even though the backoffice makes a round-trip to the database/backend. When the backend returns the data for the editor, it contains the original entity sent to the backend by the backoffice, and not the updated entity from the database.

This pull requests removes some lines of code which allows a repository to return a new version of an entity to the backoffice. This also allows for fields, which are generated and updated every save, to be updated in the UI.  