### PR TITLE
Allow repository to edit where clause

### DIFF
--- a/src/Fluidity/Data/IFluidityRepository.cs
+++ b/src/Fluidity/Data/IFluidityRepository.cs
@@ -1,8 +1,9 @@
-// <copyright file="IFluidityRepository.cs" company="Matt Brailsford">
+﻿// <copyright file="IFluidityRepository.cs" company="Matt Brailsford">
 // Copyright (c) 2017 Matt Brailsford and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
+using Fluidity.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -28,5 +29,7 @@ namespace Fluidity.Data
         void Delete(object id, bool fireEvents = true);
 
         long GetTotalRecordCount(bool fireEvents = true);
+
+        LambdaExpression CreateQueryExpression(FluidityCollectionConfig collection, ParameterExpression parameter, string query);
     }
 }

--- a/src/Fluidity/Services/FluidityEntityService.cs
+++ b/src/Fluidity/Services/FluidityEntityService.cs
@@ -99,7 +99,7 @@ namespace Fluidity.Services
 
             // Parse the order by
             LambdaExpression orderByExp = null;
-            if (!orderBy.IsNullOrWhiteSpace() && !orderBy.InvariantEquals("name"))
+            if (!orderBy.IsNullOrWhiteSpace())
             {
                 // Convert string into an Expression<Func<TEntityType, object>>
                 var prop = collection.EntityType.GetProperty(orderBy);


### PR DESCRIPTION
When developing a custom repository, it is sometimes required to adjust the way the where clause is generated. This change creates 3 override-able methods to alter the way the where clause is generated.

Examples why the where clause should be configurable:
- The default database access layer adds `ToUpper` to make where clauses case insensitive. This is not always the case when using a custom repository with, for example, Entity Framework.
- The `StartsWith` is not always the best method for the fuzzy finder, so sometimes searching using `Contains` is the better option.

Furthermore, this PR removes the skipping of the Name column in the `orderBy` clause. DefaultFluidityRepository uses `_collection.SortProperty` as a fallback for sorting, but that is unavailable for custom repositories. By never skipping the name column, the `orderBy` clause always has a usable value.