### PR TITLE
Ability to hide folders on predicate.

### DIFF
--- a/src/Fluidity/Configuration/FluidityContainerTreeItemConfig.cs
+++ b/src/Fluidity/Configuration/FluidityContainerTreeItemConfig.cs
@@ -26,6 +26,9 @@ namespace Fluidity.Configuration
         protected ConcurrentDictionary<string, FluidityTreeItemConfig> _treeItems;
         internal IReadOnlyDictionary<string, FluidityTreeItemConfig> TreeItems => _treeItems;
 
+        protected Func<bool> _isVisibleInTree;
+        internal Func<bool> IsVisibleInTree => _isVisibleInTree;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FluidityContainerTreeItemConfig"/> class.
         /// </summary>
@@ -36,8 +39,8 @@ namespace Fluidity.Configuration
             _alias = name.ToSafeAlias(true);
             _name = name;
             _icon = icon ?? "icon-folder";
-
             _treeItems = new ConcurrentDictionary<string, FluidityTreeItemConfig>();
+            _isVisibleInTree = () => true;
         }
 
         /// <summary>

--- a/src/Fluidity/Configuration/FluidityFolderConfig.cs
+++ b/src/Fluidity/Configuration/FluidityFolderConfig.cs
@@ -56,7 +56,7 @@ namespace Fluidity.Configuration
         /// </summary>
         /// <param name="whereClause"></param>
         /// <returns>The folder configuration.</returns>
-        public FluidityFolderConfig HideFromTree(Expression<Func<bool>> whereClause)
+        public FluidityFolderConfig HideFromTree(Func<bool> whereClause)
         {
             _isVisibleInTree = whereClause;
             return this;

--- a/src/Fluidity/Configuration/FluidityFolderConfig.cs
+++ b/src/Fluidity/Configuration/FluidityFolderConfig.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Linq.Expressions;
 
 namespace Fluidity.Configuration
 {
@@ -47,6 +48,17 @@ namespace Fluidity.Configuration
         public FluidityFolderConfig SetIconColor(string color)
         {
             _iconColor = color;
+            return this;
+        }
+
+        /// <summary>
+        /// Hides the folder from the section tree.
+        /// </summary>
+        /// <param name="whereClause"></param>
+        /// <returns>The folder configuration.</returns>
+        public FluidityFolderConfig HideFromTree(Expression<Func<bool>> whereClause)
+        {
+            _isVisibleInTree = whereClause;
             return this;
         }
     }

--- a/src/Fluidity/Web/Trees/FluidityTreeController.cs
+++ b/src/Fluidity/Web/Trees/FluidityTreeController.cs
@@ -88,7 +88,7 @@ namespace Fluidity.Web.Trees
             var currentItemConfig = alias == "-1" ? TreeConfig : TreeConfig.FlattenedTreeItems[alias];
 
             var currentFolderConfig = currentItemConfig as FluidityContainerTreeItemConfig;
-            if (currentFolderConfig != null)
+            if (currentFolderConfig != null && currentFolderConfig.IsVisibleInTree.Invoke())
             {
                 // Render the folder contents
                 foreach (var treeItem in currentFolderConfig.TreeItems.Values.OrderBy(x => x.Ordinal))

--- a/src/Fluidity/Web/Trees/FluidityTreeController.cs
+++ b/src/Fluidity/Web/Trees/FluidityTreeController.cs
@@ -88,13 +88,13 @@ namespace Fluidity.Web.Trees
             var currentItemConfig = alias == "-1" ? TreeConfig : TreeConfig.FlattenedTreeItems[alias];
 
             var currentFolderConfig = currentItemConfig as FluidityContainerTreeItemConfig;
-            if (currentFolderConfig != null && currentFolderConfig.IsVisibleInTree.Invoke())
+            if (currentFolderConfig != null)
             {
                 // Render the folder contents
                 foreach (var treeItem in currentFolderConfig.TreeItems.Values.OrderBy(x => x.Ordinal))
                 {
                     var folderTreeItem = treeItem as FluidityFolderConfig;
-                    if (folderTreeItem != null)
+                    if (folderTreeItem != null && folderTreeItem.IsVisibleInTree.Invoke())
                     {
                         // Render folder
                         var node = CreateTreeNode(


### PR DESCRIPTION
Based on my question #111 
Since change is so small, I have implemented the change before getting a reply.

Overall:
The current feature allows hiding folders on a predicate during the config setup.

Example:
```
    treeConfig.AddFolder("Folder", folderConfig =>
    {
        folderConfig.HideFromTree(() =>
        {
            var currentUser = UmbracoContext.Current.Security.CurrentUser;
            if (currentUser == null) return false;
            return currentUser.IsAdmin();
        });

        // ... 
    }    
```
